### PR TITLE
Add starter Flask/Firebase project files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# Salt River Shop
+
+Starter code for a simple Flask + Firebase demo application. The project
+includes a minimal backend API and static frontend pages.
+
+## Requirements
+
+- Python 3.8+
+- Node.js optional (only plain JavaScript used)
+
+Install Python dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Running
+
+1. Place your Firebase credentials in `firebase_credentials.json` and update
+   `backend/firebase-config.py` with your project settings.
+2. Start the Flask development server:
+
+```bash
+python backend/app.py
+```
+
+The app serves the pages in `frontend/pages`. Visit `http://localhost:5000` to
+see the landing page.

--- a/backend/controllers/auth.py
+++ b/backend/controllers/auth.py
@@ -1,15 +1,45 @@
+"""Authentication endpoints."""
+
 from flask import Blueprint, request, jsonify
+
 from firebase_config import auth
 
-auth_bp = Blueprint('auth', __name__)
+auth_bp = Blueprint("auth", __name__)
 
-@auth_bp.route('/signup', methods=['POST'])
+
+@auth_bp.route("/signup", methods=["POST"])
 def signup():
+    """Create a new user account."""
     data = request.get_json()
-    email = data.get('email')
-    password = data.get('password')
+    email = data.get("email")
+    password = data.get("password")
     try:
         user = auth.create_user_with_email_and_password(email, password)
-        return jsonify({"message": "Account created", "uid": user['localId']}), 200
-    except Exception as e:
+        return (
+            jsonify({"message": "Account created", "uid": user["localId"]}),
+            200,
+        )
+    except Exception as e:  # pragma: no cover - external service error text
+        return jsonify({"error": str(e)}), 400
+
+
+@auth_bp.route("/login", methods=["POST"])
+def login():
+    """Sign in an existing user."""
+    data = request.get_json()
+    email = data.get("email")
+    password = data.get("password")
+    try:
+        user = auth.sign_in_with_email_and_password(email, password)
+        return (
+            jsonify(
+                {
+                    "message": "Login successful",
+                    "idToken": user.get("idToken"),
+                    "uid": user.get("localId"),
+                }
+            ),
+            200,
+        )
+    except Exception as e:  # pragma: no cover - external service error text
         return jsonify({"error": str(e)}), 400

--- a/frontend/js/auth.js
+++ b/frontend/js/auth.js
@@ -1,14 +1,27 @@
-document.getElementById('signup-form').addEventListener('submit', async function(e) {
-  e.preventDefault();
-  const email = this.email.value;
-  const password = this.password.value;
+function handleAuth(formId, url) {
+  const form = document.getElementById(formId);
+  if (!form) return;
 
-  const res = await fetch('/auth/signup', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ email, password })
+  form.addEventListener('submit', async function (e) {
+    e.preventDefault();
+    const email = this.email.value;
+    const password = this.password.value;
+
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password })
+    });
+
+    const data = await res.json();
+    document.getElementById('response').textContent = data.message || data.error;
+
+    if (data.idToken && url.includes('login')) {
+      // Simple redirect to dashboard after login
+      window.location.href = 'dashboard.html';
+    }
   });
+}
 
-  const data = await res.json();
-  document.getElementById('response').textContent = data.message || data.error;
-});
+handleAuth('signup-form', '/auth/signup');
+handleAuth('login-form', '/auth/login');

--- a/frontend/js/dashboard.js
+++ b/frontend/js/dashboard.js
@@ -1,0 +1,31 @@
+const listingForm = document.getElementById('listing-form');
+const listingsDiv = document.getElementById('listings');
+
+async function fetchListings() {
+  const res = await fetch('/listings');
+  const data = await res.json();
+  listingsDiv.innerHTML = '';
+  if (!data) return;
+  Object.values(data).forEach(item => {
+    const div = document.createElement('div');
+    div.innerHTML = `<h3>${item.title}</h3><p>${item.description}</p>` +
+      `<img src="${item.image_url}" alt="${item.title}" width="200" />`;
+    listingsDiv.appendChild(div);
+  });
+}
+
+if (listingForm) {
+  listingForm.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const formData = new FormData(listingForm);
+    const res = await fetch('/listings', {
+      method: 'POST',
+      body: formData
+    });
+    await res.json();
+    listingForm.reset();
+    fetchListings();
+  });
+}
+
+fetchListings();

--- a/frontend/js/listings.js
+++ b/frontend/js/listings.js
@@ -1,0 +1,4 @@
+export async function getListings() {
+  const res = await fetch('/listings');
+  return res.json();
+}

--- a/frontend/pages/dashboard.html
+++ b/frontend/pages/dashboard.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Dashboard</title>
+  <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+  <div class="container">
+    <h2>Dashboard</h2>
+    <form id="listing-form" enctype="multipart/form-data">
+      <input type="text" name="title" placeholder="Title" required />
+      <textarea name="description" placeholder="Description" required></textarea>
+      <input type="text" name="user_id" placeholder="User ID" required />
+      <input type="file" name="image" accept="image/*" required />
+      <button type="submit">Create Listing</button>
+    </form>
+    <div id="listings"></div>
+  </div>
+  <script src="../js/dashboard.js"></script>
+</body>
+</html>

--- a/frontend/pages/login.html
+++ b/frontend/pages/login.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Login</title>
+  <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+  <div class="container">
+    <h2>Login</h2>
+    <form id="login-form">
+      <input type="email" name="email" placeholder="Email" required />
+      <input type="password" name="password" placeholder="Password" required />
+      <button type="submit">Login</button>
+    </form>
+    <p id="response"></p>
+  </div>
+  <script src="../js/auth.js"></script>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+flask-cors
+pyrebase4

--- a/static/ignore.txt
+++ b/static/ignore.txt
@@ -1,1 +1,1 @@
-Roshan the crippled man is crippled.
+Placeholder file for static assets.


### PR DESCRIPTION
## Summary
- flesh out README with run instructions
- implement `/login` route and improve signup handler
- add login and dashboard pages
- implement basic JS for authentication and listings management
- add initial requirements file
- remove offensive placeholder text in `static/ignore.txt`

## Testing
- `python -m py_compile backend/app.py backend/controllers/auth.py backend/controllers/listings.py backend/controllers/requests.py backend/firebase-config.py backend/utils/auth_utils.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684351e1663c83238e1c223841e51e23