### PR TITLE
Change default port to 5001

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,4 @@ Salt River is a platform that helps businesses donate surplus goods to verified 
    ```bash
    python -m backend.app
    ```
+   The API will be available at `http://localhost:5001`.

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,6 +1,7 @@
 from flask import Flask
 import firebase_admin
 from firebase_admin import credentials, initialize_app
+import os
 
 from .config import Config
 from .models import db
@@ -29,4 +30,5 @@ if __name__ == '__main__':
     app = create_app()
     with app.app_context():
         db.create_all()
-    app.run(debug=True)
+    port = int(os.getenv("PORT", 5001))
+    app.run(debug=True, port=port)


### PR DESCRIPTION
## Summary
- update README with info about port 5001
- run backend on port 5001 by default

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6849e3271d4483238529f33343f54878