### PR TITLE
Serve frontend from Flask root

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,5 @@ Salt River is a platform that helps businesses donate surplus goods to verified 
    ```bash
    python -m backend.app
    ```
-   The API will be available at `http://localhost:5001`.
+   Visit `http://localhost:5001/` to view the placeholder frontend. All API
+   endpoints are available under the `/api` path (e.g., `http://localhost:5001/api`).

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,4 +1,4 @@
-from flask import Flask
+from flask import Flask, send_from_directory
 import firebase_admin
 from firebase_admin import credentials, initialize_app
 import os
@@ -21,7 +21,7 @@ def create_app():
 
     @app.route('/')
     def index():
-        return {'message': 'Salt River API'}
+        return send_from_directory('../frontend', 'index.html')
 
     return app
 


### PR DESCRIPTION
## Summary
- serve `frontend/index.html` from the Flask root route so the app shows a page instead of raw JSON
- update README with instructions for accessing the frontend and API

## Testing
- `pip install -r requirements.txt` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6849e4185bb08323b840a657de60f6d8